### PR TITLE
fix installation: open file in text mode

### DIFF
--- a/lhapdf.in
+++ b/lhapdf.in
@@ -204,7 +204,7 @@ def get_reference_list(filepath):
     database = []
     try:
         import csv
-        csv_file = open(filepath, 'rb')
+        csv_file = open(filepath, 'r')
         logging.debug('Reading %s' % filepath)
         reader = csv.reader(csv_file, delimiter=' ', skipinitialspace=True, strict=True)
         for row in reader:


### PR DESCRIPTION
Failed to install for me with python 6.
I am no python expert, but I found that there can be some problem reading the file with the csv reader caused by charsets if the file is opened in binary mode.
The fix changes the mode to text mode, which fixes the installation for me.
No idea if this is the proper fix.