### PR TITLE
Fix the issue with webpage parsing

### DIFF
--- a/bin/lhapdf-getdata
+++ b/bin/lhapdf-getdata
@@ -34,7 +34,7 @@ def getPDFSetList(url):
         logging.debug(pdflistpage)
         hreq.close()
         import re
-        re_anchor = re.compile(r'^\s*<tr>.*<td><a\s+href="([^"]+)">\1.*$')
+        re_anchor = re.compile(r'^.*<td\s+class="name"><a\s+href=".*/.*/([^"]+)"\s+title=.*$')
         rtn = []
         for line in pdflistpage.splitlines():
             m = re_anchor.match(line)


### PR DESCRIPTION
Due to incorrect matching of the pattern to the list of files with PDF sets on the web page, they could not be downloaded.
With this change the downloading procedure should work