### PR TITLE
Changed regexp to match the current hepforge repo html output

### DIFF
--- a/bin/lhapdf-getdata
+++ b/bin/lhapdf-getdata
@@ -34,7 +34,6 @@ def getPDFSetList(url):
         logging.debug(pdflistpage)
         hreq.close()
         import re
-##        re_anchor = re.compile(r'^\s*<tr>.*<td><a\s+href="([^"]+)">\1.*$')
         re_anchor = re.compile(r'^\s*<td\s+class="name"><a.*title="([^"]+)">\1.*$')
         rtn = []
         for line in pdflistpage.splitlines():

--- a/bin/lhapdf-getdata
+++ b/bin/lhapdf-getdata
@@ -34,7 +34,8 @@ def getPDFSetList(url):
         logging.debug(pdflistpage)
         hreq.close()
         import re
-        re_anchor = re.compile(r'^\s*<tr>.*<td><a\s+href="([^"]+)">\1.*$')
+##        re_anchor = re.compile(r'^\s*<tr>.*<td><a\s+href="([^"]+)">\1.*$')
+        re_anchor = re.compile(r'^\s*<td\s+class="name"><a.*title="([^"]+)">\1.*$')
         rtn = []
         for line in pdflistpage.splitlines():
             m = re_anchor.match(line)


### PR DESCRIPTION
Downloading pdf sets from hepforge repository relies on generating a list of available pdf sets from the html output, which has changed since the release. 